### PR TITLE
Don't erase layer when we fail to find display after external display…

### DIFF
--- a/graphics/composer/2.1/default/ComposerClient.cpp
+++ b/graphics/composer/2.1/default/ComposerClient.cpp
@@ -316,7 +316,12 @@ Return<Error> ComposerClient::destroyLayer(Display display, Layer layer)
         std::lock_guard<std::mutex> lock(mDisplayDataMutex);
 
         auto dpy = mDisplayData.find(display);
-        dpy->second.Layers.erase(layer);
+        if (dpy == mDisplayData.end()) {
+            ALOGE("failed to find display");
+            return Error::BAD_DISPLAY;
+        } else {
+            dpy->second.Layers.erase(layer);
+        }
     }
 
     return err;


### PR DESCRIPTION
… is unplugged.

Test: we don't see any UI restart after unplug/plug
external display
Signed-off-by: samiuddi <sami.uddin.mohammad@intel.com>